### PR TITLE
NIP-RP: optional asset-reference `a` tag on kind:9901

### DIFF
--- a/nostr-protocols/nips/rp.md
+++ b/nostr-protocols/nips/rp.md
@@ -33,6 +33,7 @@ The following tags are used across the different kinds defined by this NIP:
 - `p`: public key of the recipient of the message.
 - `relays`: one or more relay URLs identifying the author's preferred read relays for replies and follow-up messages in the reservation thread.
 - `e`: tag used to connect all messages of the same reservation request (the reservation thread). Contains the `.id` field of the original `kind:9901` reservation request.
+- `a`: optional NIP-01 addressable event coordinate (`<kind>:<pubkey>:<d-identifier>`) identifying the specific bookable asset a `kind:9901` request targets, such as a NIP-52 time-based calendar event (`kind:31923`). If omitted, the request targets the business's default reservable resource (e.g., a table).
 - `party_size`: number of people in the reservation.
 - `time`: inclusive reservation start Unix timestamp in seconds.
 - `tzid`: time zone of the reservation `time`, `earliest_time`, and `latest_time` Unix timestamps, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`.
@@ -44,6 +45,16 @@ The following tags are used across the different kinds defined by this NIP:
 - `latest_time`: latest start time that the requestor would accept for the reservation.
 - `status`: status of the reservation as one of the following values `confirmed`, `declined`, or `cancelled`.
 - `broker`: set to `true` if the party initiating the reservation flow is not the reservation holder
+
+### Bookable Asset Reference
+
+A `kind:9901` request MAY include an `a` tag identifying the specific bookable asset it targets, using a NIP-01 addressable event coordinate of the form `<kind>:<pubkey>:<d-identifier>`. This lets one business offer distinct reservable assets and lets the request name exactly which one it wants — for example a scheduled event published as a NIP-52 time-based calendar event (`kind:31923`):
+
+```yaml
+["a", "31923:<businessPublicKey>:<event-d-identifier>"]
+```
+
+If the `a` tag is omitted, the request targets the business's default/general reservable resource — for a restaurant, a table. The asset is established by the `kind:9901` request and applies to the whole thread; follow-up messages (`kind:9902`/`9903`/`9904`) identify the thread via the `e` tag and need not repeat the `a` tag.
 
 ## Relay Routing
 
@@ -81,6 +92,7 @@ The `p` tag identifies the recipient's public key. Clients MUST use the `relays`
     ["duration", "<optional duration of reservation in seconds>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
     ["latest_time", "<optional unix timestamp in seconds>"],
+    ["a", "<optional addressable event coordinate '<kind>:<pubkey>:<d>' naming the bookable asset, e.g. a NIP-52 kind:31923 event; omit for a general reservation such as a table>"],
     ["broker", "<optional boolean, 'true' | 'false'>"] 
   ],
   "content": "<reservation request message in plain text>"

--- a/nostrability/schemata/nips/nip-rp/kind-9901/schema.yaml
+++ b/nostrability/schemata/nips/nip-rp/kind-9901/schema.yaml
@@ -225,6 +225,29 @@ allOf:
                   additionalItems: false
             errorMessage:
               anyOf: "broker tag, if present, must have format ['broker', '<True|False>']"
+          - anyOf:
+              - not:
+                  contains:
+                    type: array
+                    minItems: 1
+                    items:
+                      - const: "a"
+              - contains:
+                  type: array
+                  minItems: 2
+                  maxItems: 3
+                  items:
+                    - const: "a"
+                      description: "Tag identifier"
+                    - type: string
+                      pattern: "^[0-9]+:[0-9a-f]{64}:.*$"
+                      description: "Addressable event coordinate '<kind>:<pubkey>:<d-identifier>' identifying the bookable asset (e.g., a NIP-52 kind:31923 event). Omit for a general reservation such as a table."
+                      errorMessage: "a tag value must be an addressable event coordinate '<kind>:<pubkey>:<d-identifier>'"
+                    - type: string
+                      description: "Optional relay URL hint"
+                  additionalItems: false
+            errorMessage:
+              anyOf: "a tag, if present, must have format ['a', '<kind>:<pubkey>:<d-identifier>']"
     required:
       - kind
       - id


### PR DESCRIPTION
Adds an optional `a` tag to `kind:9901` so a reservation request can name the specific bookable asset it targets — the Phase-2 dependency flagged in the [Reservations PRD §7](https://github.com/Synvya/docs/blob/main/06-domains-and-services/specs/prd-reservations.md).

## What

- **`a` tag** = a NIP-01 addressable event coordinate `<kind>:<pubkey>:<d-identifier>` naming the asset — e.g. a NIP-52 time-based calendar event `31923:<business>:<d>`.
- **Absent ⇒ default resource** (for a restaurant, a table). So the change is **optional and backward compatible** — existing `9901` requests remain valid.
- The asset is set by the `9901` and applies to the whole thread; follow-ups keep using the `e` tag.

## Files

- `nostr-protocols/nips/rp.md` — tag glossary entry, the `9901` rumor structure, and a new **Bookable Asset Reference** section.
- `nostrability/schemata/nips/nip-rp/kind-9901/schema.yaml` — optional `a` tag (coordinate pattern + optional relay hint). Validated as parseable YAML.

Kept deliberately generic (NIP-RP spans restaurants/hotels/appointments); the restaurant/event mapping lives in the Synvya PRD. Downstream: `@synvya/capabilities` builder/parser + `server`/`diners` consume it when Phase-2 events are built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)